### PR TITLE
Refactor(user access): Introduce user type that should react to posts…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 coverage
+PR.md

--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -20,18 +20,19 @@ afterAll(async () => {
 
 describe('Create a user', () => {
     beforeAll(async () => {
-        await Users.deleteMany({})
+        await Users.deleteMany({ userType: "user" })
     }, 20000)
 
     it('should sign up a user', async () => {
         const user = await supertest(app).post('/users').send({
             names: "cyusa kheven",
-            phone: "0783903252",
-            email: "cyusa.kheven@outlook.com",
+            phone: "0722982335",
+            email: "cyusa.kheven@yahoo.com",
             dob: new Date('02-12-2000'),
             password: '123456',
             photo: "https://picsum.photos/200/200"
         })
+        expect(user.body.message).toContain("success")
         expect(user.status).toBe(201)
 
     })

--- a/controllers/messages.controller.js
+++ b/controllers/messages.controller.js
@@ -27,6 +27,11 @@ export async function createMessage(req, res) {
 
 export async function getMessages(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const messages = await Messages.find()
         if (messages) res.status(200).json({
             message: "success",
@@ -45,6 +50,11 @@ export async function getMessages(req, res) {
 
 export async function replyMessage(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const id = req.params.id
         const { reply } = req.body
         const repliedMessage = await Messages.findByIdAndUpdate(id, { reply, replyDate: new Date() }, { new: true })
@@ -64,6 +74,11 @@ export async function replyMessage(req, res) {
 
 export async function deleteMessage(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const id = req.params.id
         const result = await Messages.findByIdAndDelete(id)
         if (result) res.status(200).json({ message: "success", data: result })

--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -23,8 +23,11 @@ export async function getPosts(req, res) {
 export async function addPost(req, res) {
     const { title, intro, body, photo, tags } = req.body
     try {
-        // const photoURL = await upload(req.file?.path)
-        // if (photoURL.secure_url == null) throw "Could not upload image properly.."
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         let newPost = new Post({
             title,
             intro,
@@ -70,6 +73,11 @@ export async function getOnePost(req, res) {
 
 export async function deletePost(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const { id } = req.params
         const post = await Post.deleteOne({ _id: id })
         if (post) res.status(200).json({ message: "success", data: post })
@@ -83,6 +91,11 @@ export async function deletePost(req, res) {
 
 export async function updateByID(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const { id } = req.params
         const data = req.body
         const post = await Post.findOne({ _id: id })
@@ -90,13 +103,7 @@ export async function updateByID(req, res) {
             res.status(400).json({ message: "There is no post with this ID.." })
             return
         }
-        // let photoURL, picture = {}
-        // if (req.file) {
-        //     photoURL = await upload(req.file.path)
-        //     if (photoURL.secure_url == null) throw "Could not upload image properly.."
-        //     picture = { photo: photoURL.secure_url }
-        // }
-        // return console.log({ data, body: req.body, post, picture })
+
         const updatedPost = Object.assign(post, data)
         const newPost = await Post.findByIdAndUpdate(id, updatedPost, { new: true })
         if (newPost) res.status(200).json({

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -7,6 +7,10 @@ import { Users } from './../models/user.model.js'
 
 export async function getAllUsers(req, res) {
     try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
         const users = await Users.find()
         res.status(200).json({
             message: "success",
@@ -80,6 +84,10 @@ export async function getUserByEmail(req, res) {
                 length: 0,
                 data: {}
             })
+        if (req.user.userType !== 'admin' && req.user._id !== user._id) return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
         else res.status(200).json({
             message: "success",
             length: user.length,
@@ -96,7 +104,14 @@ export async function getUserByEmail(req, res) {
 
 export async function updateUser(req, res) {
     try {
+        
         const id = req.params.id
+        
+        if (req.user.userType !== 'admin' && req.user._id !== id) return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+        
         const { names, email, phone, password, dob, photo } = req.body
         
         const user = Users.findById(id)
@@ -124,6 +139,12 @@ export async function updateUser(req, res) {
 export async function deleteOneUser(req, res) {
     try {
         const id = req.params.id
+
+        if (req.user.userType !== 'admin' && req.user._id !== id) return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
         const data = await Users.findByIdAndDelete(id)
         res.status(200).json({
             message: "success",
@@ -147,8 +168,9 @@ export async function auth(req, res) {
         // jwt stuff
         const authenticatedUser = {
             names: user.names,
-            id: user._id,
-            email: user.email
+            _id: user._id,
+            email: user.email,
+            userType: user.userType
         }
         const token = jwt.sign(authenticatedUser, process.env.JWT_TOKEN)
         res.status(200).json({

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -40,6 +40,10 @@ const UserSchema = Schema({
     dob: {
         type: Date,
         required: true
+    },
+    userType: {
+        type: String,
+        default: 'user'
     }
 })
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --watchAll",
     "start": "node index.js",
     "dev": "nodemon index.js",
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --watchAll",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "start": "node index.js",
     "dev": "nodemon index.js",
     "lint": "eslint ."

--- a/routes/posts.routes.js
+++ b/routes/posts.routes.js
@@ -27,11 +27,11 @@ router.delete("/:id", authenticateRoute, deletePost);
 router.patch("/:id", upload.none(), validatePostUpdate, authenticateRoute, updateByID);
 
 // Add comment Route
-router.post('/:id/comment', upload.none(), validateComment, addComment)
+router.post('/:id/comment', upload.none(), authenticateRoute, validateComment, addComment)
 // Get comments of a specific post
 router.get('/:id/comment', getComments)
 
 // Add like Route
-router.post('/:id/like', upload.none(), validateLike, AddLike)
+router.post('/:id/like', upload.none(), authenticateRoute, validateLike, AddLike)
 
 export default router;

--- a/routes/users.routes.js
+++ b/routes/users.routes.js
@@ -11,7 +11,7 @@ const router = express.Router()
 
 router.get('/', authenticateRoute, getAllUsers)
 router.post('/', upload.single('photo'), ValidateUser, addUser)
-router.get('/email', getUserByEmail)
+router.get('/email', authenticateRoute, getUserByEmail)
 router.get('/:id', getOneUser)
 router.patch('/:id', upload.single('photo'), validateUserUpdate, authenticateRoute, updateUser)
 router.delete("/:id", authenticateRoute, deleteOneUser)

--- a/swagger.json
+++ b/swagger.json
@@ -46,9 +46,6 @@
         "User": {
           "type": "object",
           "properties": {
-            "id": {
-              "type": "string"
-            },
             "names": {
               "type": "string"
             },

--- a/validators/messages.validator.js
+++ b/validators/messages.validator.js
@@ -11,7 +11,7 @@ export async function validateMessage(req, res, next) {
         })
         const { error } = schema.validate(req.body)
         if (error) {
-            console.error(error)
+            // console.error(error)
             return res.status(400).json({
                 message: "Unable to save this message..",
                 error: error.message
@@ -35,7 +35,7 @@ export async function validateReply(req, res, next) {
         })
         const { error } = schema.validate(req.body)
         if (error) {
-            console.log(error)
+            // console.log(error)
             return res.status(400).json({
                 message: 'Unable to reply this message..',
                 error: error.message


### PR DESCRIPTION
#### What does this PR do?
Introduce user type that should react to posts and comment but not access the dashboard
#### Description of Task to be completed?
- Have 2 types of users: `admin` and `user`
- Now a `user` should manage his own account. No other `user` can access other account except the `admin`
#### How should this be manually tested?
- Clone this repo
- Enter in the repo folder
- Run `npm ci` from terminal/CMD
- Run `npm start` from terminal/CMD
#### Any background context you want to provide?
- Must login to access some routes