### PR TITLE
feature(skills): Add a functionality so that an admin user can create skills

### DIFF
--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -1,0 +1,213 @@
+import mongoose from "mongoose";
+import createServer from "../utils/server";
+import { Skills } from "../models/skills.model";
+import { Users } from "../models/user.model";
+import supertest from "supertest";
+
+const app = createServer()
+
+beforeAll(async () => {
+    mongoose.set('strictQuery', false)
+    await mongoose.connect(process.env.DATABASE_TEST_URL)
+    await Skills.deleteMany({})
+
+})
+afterAll(async () => {
+    await mongoose.connection.close()
+
+})
+
+describe("Test skills route", () => {
+    let adminToken
+    let skillID
+    describe("Get skills", () => {
+        it("Should return 404 if skills are empty", async () => {
+            const res = await supertest(app).get('/skills')
+            expect(res.status).toBe(404)
+            expect(res.body.message).toContain("success")
+        })
+    })
+
+    describe('Test validation', () => {
+        it("Should return 400 if skillname is missing", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skilldesc: "frontend javascript framework",
+                skillphoto: "https://picsum.photos/100/100",
+                skillbanner: "https://picsum.photos/100/100"
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if skilldesc is missing", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skillphoto: "https://picsum.photos/100/100",
+                skillbanner: "https://picsum.photos/100/100",
+                skillname: "react"
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if skillphoto is missing", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skillname: "react",
+                skilldesc: "frontend javascript framework",
+                skillbanner: "https://picsum.photos/100/100"
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if skillbanner is missing", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skillname: "react",
+                skilldesc: "frontend javascript framework",
+                skillphoto: "https://picsum.photos/100/100"
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if there is additional field not defined", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skillname: "react",
+                skilldesc: "frontend javascript framework",
+                skillphoto: "https://picsum.photos/100/100",
+                skillbanner: "https://picsum.photos/100/100",
+                other: "not defined"
+            })
+            expect(res.status).toBe(400)
+        })
+
+    })
+
+    describe("Test without token", () => {
+        it("Should return 401 when token is not available", async () => {
+            const res = await supertest(app).post('/skills').send({
+                skillname: "react",
+                skilldesc: "frontend javascript framework",
+                skillphoto: "https://picsum.photos/100/100",
+                skillbanner: "https://picsum.photos/100/100"
+            })
+            expect(res.status).toBe(401)
+        })
+    })
+
+    describe("Test with admin", () => {
+
+        beforeAll(async () => {
+            const res = await supertest(app).post('/login').send({
+                email: "cyusa.kheven@outlook.com",
+                password: "123456"
+            })
+            adminToken = res.body.token
+        })
+        afterAll(async () => {
+            adminToken = ''
+            // await Skills.deleteMany({})
+        })
+        it("Should return 201 when there is token and user is admin", async () => {
+            const res = await supertest(app).post('/skills').set("Authorization", "Bearer " + adminToken)
+                .send({
+                    skillname: "react",
+                    skilldesc: "frontend javascript framework",
+                    skillphoto: "https://picsum.photos/100/100",
+                    skillbanner: "https://picsum.photos/100/100"
+                })
+            expect(res.status).toBe(201)
+            expect(res.body.message).toContain("success")
+            skillID = res.body.data._id
+        })
+        it("should return 200 when skill is updated", async () => {
+            const res = await supertest(app).patch(`/skills/${skillID}`).set("Authorization", "Bearer " + adminToken)
+                .send({
+                    skillname: "react patch test",
+                    skilldesc: "frontend javascript framework test",
+                    skillphoto: "https://picsum.photos/100/100",
+                    skillbanner: "https://picsum.photos/100/100"
+                })
+            expect(res.status).toBe(200)
+            expect(res.body.message).toContain("success")
+        })
+        ////////////
+        describe("Get skills", () => {
+            it("Should return 200 if there are skills", async () => {
+                const res = await supertest(app).get('/skills')
+                expect(res.status).toBe(200)
+                expect(res.body.message).toContain("success")
+            })
+            it("should return 404 when a skill with not available", async () => {
+                const res = await supertest(app).get(`/skills/63e7945da899ae003ff00c9d`)
+                expect(res.status).toBe(404)
+                expect(res.body.message).toContain("Not found")
+            })
+            it("should return 200 if there is `skill` with ID", async () => {
+                const res = await supertest(app).get(`/skills/${skillID}`)
+                expect(res.status).toBe(200)
+                expect(res.body.message).toContain("success")
+            })
+        })
+        // ?????
+        describe("Test with simple user", () => {
+            let user = {}
+            let token
+            beforeAll(async () => {
+                user = await supertest(app).post('/users').send({
+                    names: "cyusa kheven",
+                    phone: "0722002335",
+                    email: "cyusa.kheven@aol.com",
+                    dob: new Date('02-12-2000'),
+                    password: '123456',
+                    photo: "https://picsum.photos/200/200"
+                })
+                if (user.status == 201) {
+                    const res = await supertest(app).post('/login').send({
+                        email: 'cyusa.kheven@aol.com',
+                        password: '123456'
+                    })
+                    token = res.body.token
+                }
+            })
+            afterAll(async () => {
+                await Users.deleteMany({ userType: "user" })
+            })
+            // TESTS
+            it("Should return 403 if the user is not an admin", async () => {
+                const res = await supertest(app).post('/skills').set("Authorization", "Bearer " + token)
+                    .send({
+                        skillname: "react",
+                        skilldesc: "frontend javascript framework",
+                        skillphoto: "https://picsum.photos/100/100",
+                        skillbanner: "https://picsum.photos/100/100"
+                    })
+                expect(res.status).toBe(403)
+            })
+            it("should return 403 when skill is updated by simple user/unauthenticated", async () => {
+                const res = await supertest(app).patch(`/skills/${skillID}`).set("Authorization", "Bearer " + token)
+                    .send({
+                        skillname: "react patch test",
+                        skilldesc: "frontend javascript framework test",
+                        skillphoto: "https://picsum.photos/100/100",
+                        skillbanner: "https://picsum.photos/100/100"
+                    })
+                expect(res.status).toBe(403)
+            })
+            it("should return 403 when skill is deleted by simple user/unauthenticated", async () => {
+                const res = await supertest(app).delete(`/skills/${skillID}`).set("Authorization", "Bearer " + token)
+
+                expect(res.status).toBe(403)
+            })
+        })
+
+        // ?????
+        ////////////
+        it("should return 404 when a a deleted skill is not available", async () => {
+            const res = await supertest(app).delete(`/skills/63e7945da899ae003ff00c9d`).set("Authorization", "Bearer " + adminToken)
+            expect(res.status).toBe(404)
+            expect(res.body.message).toContain("Skill not found")
+        })
+
+        it("Should return 200 when skill is deleted successfully", async () => {
+            const res = await supertest(app).delete(`/skills/${skillID}`).set("Authorization", "Bearer " + adminToken)
+
+            expect(res.status).toBe(200)
+        })
+
+    })
+
+
+})
+

--- a/controllers/skills.controller.js
+++ b/controllers/skills.controller.js
@@ -1,0 +1,106 @@
+import { Skills } from "../models/skills.model.js"
+
+
+
+export function addSkill(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const { skillname, skilldesc, skillphoto, skillbanner } = req.body
+        const newSkill = new Skills({ skillname, skilldesc, skillphoto, skillbanner })
+        newSkill.save((err, result) => {
+            if (err) return res.status(400).json({ message: err.message, error: err })
+            res.status(201).json({ message: "success", data: result })
+        })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function getSkills(req, res) {
+    try {
+        const skills = await Skills.find()
+        if (skills.length == 0) res.status(404).json({ message: "success", length: 0, data: {} })
+        else res.status(200).json({ message: "success", length: skills.length, data: skills })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function getSkillById(req, res) {
+    try {
+        const id = req.params.id
+        const skill = await Skills.findById(id)
+        if (skill == null) res.status(404).json({ message: "Not found", data: {} })
+        else res.status(200).json({ message: "success", data: skill })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function updateSkill(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const id = req.params.id
+        const { skillname, skilldesc, skillphoto, skillbanner } = req.body
+        const skill = await Skills.findById(id)
+        if (skill == null) res.status(404).json({ message: "Skill not found", data: {} })
+        else {
+            const newSkill = {
+                skillname: skillname || skill.skillname,
+                skilldesc: skilldesc || skill.skilldesc,
+                skillphoto: skillphoto || skill.skillphoto,
+                skillbanner: skillbanner || skill.skillbanner,
+                modifiedDate: new Date()
+            }
+            const response = await Skills.findByIdAndUpdate(id, newSkill, { new: true })
+            if (response) res.status(200).json({ message: "success", data: response })
+            else res.status(400).json({ message: "error" })
+        }
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function deleteSkill(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const id = req.params.id
+        const response = await Skills.findByIdAndDelete(id)
+        if (response) res.status(200).json({ message: "sucess", data: response })
+        else res.status(400).json({ message: "Could not delete" })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}

--- a/models/skills.model.js
+++ b/models/skills.model.js
@@ -1,0 +1,34 @@
+import mongoose from "mongoose";
+
+const { Schema, model } = mongoose
+
+const SkillsSchema = new Schema({
+    skillname: {
+        type: String,
+        required: true
+    },
+    skilldesc: {
+        type: String,
+        required: true,
+    },
+    skillphoto: {
+        type: String,
+        required: true,
+        default: "https://picsum.com/130/130"
+    },
+    skillbanner: {
+        type: String,
+        required: true,
+        default: "https://picsum.photos/130/90"
+    },
+    createdAt: {
+        type: Date,
+        default: new Date(),
+    },
+    modifiedDate: {
+        type: Date,
+        default: new Date()
+    }
+})
+
+export const Skills = model('skills', SkillsSchema)

--- a/routes/skills.routes.js
+++ b/routes/skills.routes.js
@@ -1,0 +1,17 @@
+import express from "express";
+import { addSkill, deleteSkill, getSkillById, getSkills, updateSkill } from "../controllers/skills.controller.js";
+import authenticateRoute from "../middlewares/auth.middleware.js";
+import { validateAddSkill, validateDelete, validateUpdateskill } from "../validators/skills.validator.js";
+import multer from "./../utils/multer_uploader.js"
+
+const router = express.Router()
+const upload = multer()
+
+router.post('/', upload.none(), validateAddSkill, authenticateRoute, addSkill)
+router.get('/:id', getSkillById)
+router.get('/', getSkills)
+router.patch('/:id', upload.none(), authenticateRoute, validateUpdateskill, updateSkill)
+router.delete('/:id', validateDelete, authenticateRoute, deleteSkill)
+
+
+export default router

--- a/swagger.json
+++ b/swagger.json
@@ -9,11 +9,11 @@
     "servers": [
       {
         "url": "http://localhost:6001",
-        "name": "Local Machine"
+        "name": "Local server"
       },
       {
         "url": "https://mybrand-backend.up.railway.app/",
-        "name": "Production Server"
+        "name": "production server"
       }
     ],
     "tags": [
@@ -32,6 +32,10 @@
       {
         "name": "MESSAGES OPERATIONS",
         "description": "message route operations"
+      },
+      {
+        "name": "SKILLS OPERATIONS",
+        "description": "Skills route operations"
       }
     ],
     "components": {
@@ -46,6 +50,9 @@
         "User": {
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string"
+            },
             "names": {
               "type": "string"
             },
@@ -125,6 +132,27 @@
             "body": {
               "type": "string",
               "description": "message"
+            }
+          }
+        },
+        "Skill": {
+          "type": "object",
+          "properties": {
+            "skillname": {
+              "type": "string",
+              "description": "name of a skill"
+            },
+            "skilldesc": {
+              "type": "string",
+              "description": "Description a single skill"
+            },
+            "skillphoto": {
+              "type": "string",
+              "description": "a photo of a skill"
+            },
+            "skillbanner": {
+              "type": "string",
+              "description": "photo(banner) to a single skill"
             }
           }
         }
@@ -567,6 +595,206 @@
                 "application/json": {
                   "schema": {
                     "$ref": "#/components/schemas/Message"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        }
+      },
+      "/skills": {
+        "get": {
+          "summary": "Get all skils in array",
+          "tags": ["SKILLS OPERATIONS"],
+          "responses": {
+            "200": {
+              "description": "List of skills received",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Skill"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "404": {
+              "description": "No skill found"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "post": {
+          "summary": "send a new skill",
+          "tags": ["SKILLS OPERATIONS"],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "$ref": "#/components/schemas/Skill"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Skill added successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Skill"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        }
+      },
+      "/skills/{id}": {
+        "patch": {
+          "summary": "Updates an existing skill",
+          "tags": ["SKILLS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of skill"
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "$ref": "#/components/schemas/Skill"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "skill updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Skill"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "get": {
+          "summary": "retreive a single skill by ID",
+          "tags": ["SKILLS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of skill"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "skill retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Skill"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "delete": {
+          "summary": "Deletes a single skill by ID",
+          "tags": ["SKILLS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of skill"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "skill deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Skill"
                   }
                 }
               }

--- a/utils/server.js
+++ b/utils/server.js
@@ -6,6 +6,7 @@ import postRoute from '../routes/posts.routes.js'
 import usersRoute from '../routes/users.routes.js'
 import loginRoute from '../routes/auth.routes.js'
 import messagesRoute from "../routes/messages.routes.js"
+import skillsRoute from "../routes/skills.routes.js"
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const swaggerJSON = require('./../swagger.json')
@@ -23,6 +24,7 @@ export default function createServer() {
     app.use('/documentation', swaggerUI.serve, swaggerUI.setup(specs))
     app.use('/posts', postRoute)
     app.use('/users', usersRoute)
+    app.use('/skills', skillsRoute)
     app.use('/messages', messagesRoute)
     app.use('/login', loginRoute)
 

--- a/validators/skills.validator.js
+++ b/validators/skills.validator.js
@@ -1,0 +1,79 @@
+import Joi from 'joi';
+import { Skills } from '../models/skills.model.js';
+
+export async function validateAddSkill(req, res, next) {
+    try {
+        const schema = Joi.object({
+            skillname: Joi.string().required().label('skillname'),
+            skilldesc: Joi.string().required().label("skilldesc"),
+            skillphoto: Joi.string().required().label("skillphoto"),
+            skillbanner: Joi.string().required().label("skillbanner"),
+        })
+
+        const { error } = schema.validate(req.body)
+        if (error) {
+            console.log(error)
+            return res.status(400).json({
+                message: "Unable to save this skill..",
+                error: error.message
+            })
+        }
+
+        next()
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function validateUpdateskill(req, res, next) {
+    try {
+        const schema = Joi.object({
+            skillname: Joi.string().empty('').label('skillname'),
+            skilldesc: Joi.string().empty('').label("skilldesc"),
+            skillphoto: Joi.string().empty('').label("skillphoto"),
+            skillbanner: Joi.string().empty('').label("skillbanner"),
+        })
+
+        const { error } = schema.validate(req.body)
+        if (error) {
+            console.log(error)
+            return res.status(400).json({
+                message: "Unable to update this skill..",
+                error: error.message
+            })
+        }
+        const id = req.params.id
+        const skill = await Skills.findById(id)
+        if (!skill) return res.status(404).json({ message: "Skill not found" })
+
+        next()
+
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function validateDelete(req, res, next) {
+    try {
+        const id = req.params.id
+        const skill = await Skills.findById(id)
+        if (!skill) return res.status(404).json({ message: "Skill not found" })
+
+
+        next()
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
- Add feature to store list of skills in the database
#### Description of Task to be completed?
- Now using `/skills` route, users should make CRUD operations on `skills` model
- get `/skills` returns an array of skills
- get `/skills/{id}` return an object(skill) with `id`
- patch `/skills/{id}` updates an object(skill) with `id`
- delete `/skills/{id}` deletes an object(skill) with `id`
#### How should this be manually tested?
- Clone this repo
- Enter in the repo folder
- Run `npm ci` from terminal/CMD
- Run `npm start` from terminal/CMD
#### Any background context you want to provide?
- Must login to access some routes