### PR TITLE
feature(works): Add a functionality so that an admin user can create works(portofolio)

### DIFF
--- a/__tests__/works.test.js
+++ b/__tests__/works.test.js
@@ -1,0 +1,232 @@
+import mongoose from "mongoose";
+import createServer from "../utils/server";
+import { Works } from "../models/works.model";
+import { Users } from "../models/user.model";
+import supertest from "supertest";
+
+const app = createServer()
+
+beforeAll(async () => {
+    mongoose.set('strictQuery', false)
+    await mongoose.connect(process.env.DATABASE_TEST_URL)
+    await Works.deleteMany({})
+
+})
+afterAll(async () => {
+    await mongoose.connection.close()
+
+})
+
+describe("Test works route", () => {
+    let adminToken
+    let workID
+    describe("Get works", () => {
+        it("Should return 404 if works are empty", async () => {
+            const res = await supertest(app).get('/works')
+            expect(res.status).toBe(404)
+            expect(res.body.message).toContain("success")
+        })
+    })
+
+    describe('Test validation', () => {
+        it("Should return 400 if workname is missing", async () => {
+            const res = await supertest(app).post('/works').send({
+                workdesc: "frontend javascript framework",
+                workimg: "https://picsum.photos/100/100",
+                link_to_project: "https://cyberleague.io",
+                frameworks: ['flask', 'vuejs'],
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if workdesc is missing", async () => {
+            const res = await supertest(app).post('/works').send({
+                workimg: "https://picsum.photos/100/100",
+                link_to_project: "https://cyberleague.io",
+                workname: "react",
+                frameworks: ['flask', 'vuejs'],
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if workimg is missing", async () => {
+            const res = await supertest(app).post('/works').send({
+                workname: "react",
+                workdesc: "frontend javascript framework",
+                link_to_project: "https://cyberleague.io",
+                frameworks: ['flask', 'vuejs'],
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if link_to_project is missing", async () => {
+            const res = await supertest(app).post('/works').send({
+                workname: "react",
+                workdesc: "frontend javascript framework",
+                workimg: "https://picsum.photos/100/100",
+                frameworks: ['flask', 'vuejs'],
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if frameworks is missing", async () => {
+            const res = await supertest(app).post('/works').send({
+                workname: "react",
+                workdesc: "frontend javascript framework",
+                workimg: "https://picsum.photos/100/100",
+                link_to_project: "https://cyberleague.io"
+            })
+            expect(res.status).toBe(400)
+        })
+        it("Should return 400 if there is additional field not defined", async () => {
+            const res = await supertest(app).post('/works').send({
+                workname: "react",
+                workdesc: "frontend javascript framework",
+                workimg: "https://picsum.photos/100/100",
+                link_to_project: "https://cyberleague.io",
+                frameworks: ['flask', 'vuejs'],
+                other: "not defined"
+            })
+            expect(res.status).toBe(400)
+        })
+
+    })
+
+    describe("Test without token", () => {
+        it("Should return 401 when token is not available", async () => {
+            const res = await supertest(app).post('/works').send({
+                workname: "react",
+                workdesc: "frontend javascript framework",
+                workimg: "https://picsum.photos/100/100",
+                link_to_project: "https://cyberleague.io",
+                frameworks: ['flask', 'vuejs'],
+            })
+            expect(res.status).toBe(401)
+        })
+    })
+
+    describe("Test with admin", () => {
+
+        beforeAll(async () => {
+            const res = await supertest(app).post('/login').send({
+                email: "cyusa.kheven@outlook.com",
+                password: "123456"
+            })
+            adminToken = res.body.token
+        })
+        afterAll(async () => {
+            adminToken = ''
+            // await works.deleteMany({})
+        })
+        it("Should return 201 when there is token and user is admin", async () => {
+            const res = await supertest(app).post('/works').set("Authorization", "Bearer " + adminToken)
+                .send({
+                    workname: "react",
+                    workdesc: "frontend javascript framework",
+                    workimg: "https://picsum.photos/100/100",
+                    link_to_project: "https://picsum.photos/100/100",
+                    frameworks: ['flask', 'vuejs'],
+                })
+            expect(res.status).toBe(201)
+            expect(res.body.message).toContain("success")
+            workID = res.body.data._id
+        })
+        it("should return 200 when work is updated", async () => {
+            const res = await supertest(app).patch(`/works/${workID}`).set("Authorization", "Bearer " + adminToken)
+                .send({
+                    workname: "react patch test",
+                    workdesc: "frontend javascript framework test",
+                    workimg: "https://picsum.photos/100/100",
+                    link_to_project: "https://picsum.photos/100/100",
+                    frameworks: ['flask', 'vuejs'],
+                })
+            expect(res.status).toBe(200)
+            expect(res.body.message).toContain("success")
+        })
+        ////////////
+        describe("Get works", () => {
+            it("Should return 200 if there are works", async () => {
+                const res = await supertest(app).get('/works')
+                expect(res.status).toBe(200)
+                expect(res.body.message).toContain("success")
+            })
+            it("should return 404 when a work with not available", async () => {
+                const res = await supertest(app).get(`/works/63e7945da899ae003ff00c9d`)
+                expect(res.status).toBe(404)
+                expect(res.body.message).toContain("Not found")
+            })
+            it("should return 200 if there is `work` with ID", async () => {
+                const res = await supertest(app).get(`/works/${workID}`)
+                expect(res.status).toBe(200)
+                expect(res.body.message).toContain("success")
+            })
+        })
+        // ?????
+        describe("Test with simple user", () => {
+            let user = {}
+            let token
+            beforeAll(async () => {
+                user = await supertest(app).post('/users').send({
+                    names: "cyusa kheven",
+                    phone: "0722002335",
+                    email: "cyusa.kheven@aol.com",
+                    dob: new Date('02-12-2000'),
+                    password: '123456',
+                    photo: "https://picsum.photos/200/200"
+                })
+                if (user.status == 201) {
+                    const res = await supertest(app).post('/login').send({
+                        email: 'cyusa.kheven@aol.com',
+                        password: '123456'
+                    })
+                    token = res.body.token
+                }
+            })
+            afterAll(async () => {
+                await Users.deleteMany({ userType: "user" })
+            })
+            // TESTS
+            it("Should return 403 if the user is not an admin", async () => {
+                const res = await supertest(app).post('/works').set("Authorization", "Bearer " + token)
+                    .send({
+                        workname: "react",
+                        workdesc: "frontend javascript framework",
+                        workimg: "https://picsum.photos/100/100",
+                        link_to_project: "https://picsum.photos/100/100",
+                        frameworks: ['flask', 'vuejs'],
+                    })
+                expect(res.status).toBe(403)
+            })
+            it("should return 403 when work is updated by simple user/unauthenticated", async () => {
+                const res = await supertest(app).patch(`/works/${workID}`).set("Authorization", "Bearer " + token)
+                    .send({
+                        workname: "react patch test",
+                        workdesc: "frontend javascript framework test",
+                        workimg: "https://picsum.photos/100/100",
+                        link_to_project: "https://picsum.photos/100/100",
+                        frameworks: ['flask', 'vuejs'],
+                    })
+                expect(res.status).toBe(403)
+            })
+            it("should return 403 when work is deleted by simple user/unauthenticated", async () => {
+                const res = await supertest(app).delete(`/works/${workID}`).set("Authorization", "Bearer " + token)
+
+                expect(res.status).toBe(403)
+            })
+        })
+
+        // ?????
+        ////////////
+        it("should return 404 when a a deleted work is not available", async () => {
+            const res = await supertest(app).delete(`/works/63e7945da899ae003ff00c9d`).set("Authorization", "Bearer " + adminToken)
+            expect(res.status).toBe(404)
+            expect(res.body.message).toContain("Work not found")
+        })
+
+        it("Should return 200 when work is deleted successfully", async () => {
+            const res = await supertest(app).delete(`/works/${workID}`).set("Authorization", "Bearer " + adminToken)
+
+            expect(res.status).toBe(200)
+        })
+
+    })
+
+
+})
+

--- a/controllers/works.controller.js
+++ b/controllers/works.controller.js
@@ -1,0 +1,106 @@
+import { Works } from "../models/works.model.js"
+
+
+export function addWork(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const { workname, workdesc, link_to_project, frameworks, workimg } = req.body
+        const newWork = new Works({ workname, workdesc, link_to_project, frameworks, workimg })
+        newWork.save((err, result) => {
+            if (err) return res.status(400).json({ message: err.message, error: err })
+            res.status(201).json({ message: "success", data: result })
+        })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function getWorks(req, res) {
+    try {
+        const works = await Works.find()
+        if (works.length == 0) res.status(404).json({ message: "success", length: 0, data: {} })
+        else res.status(200).json({ message: "success", length: works.length, data: works })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function getWorkById(req, res) {
+    try {
+        const id = req.params.id
+        const work = await Works.findById(id)
+        if (work == null) res.status(404).json({ message: "Not found", data: {} })
+        else res.status(200).json({ message: "success", data: work })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function updateWork(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const id = req.params.id
+        const { workname, workdesc, link_to_project, frameworks, workimg } = req.body
+        const work = await Works.findById(id)
+        if (work == null) res.status(404).json({ message: "Work not found", data: {} })
+        else {
+            const newWork = {
+                workname: workname || work.workname,
+                workdesc: workdesc || work.workdesc,
+                workimg: workimg || work.workimg,
+                link_to_project: link_to_project || work.link_to_project,
+                frameworks: frameworks || work.frameworks,
+                modifiedDate: new Date()
+            }
+            const response = await Works.findByIdAndUpdate(id, newWork, { new: true })
+            if (response) res.status(200).json({ message: "success", data: response })
+            else res.status(400).json({ message: "error" })
+        }
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function deleteWork(req, res) {
+    try {
+        if (req.user.userType !== 'admin') return res.status(403).json({
+            message: "Admin only are allowed to access this resource",
+            error: true
+        })
+
+        const id = req.params.id
+        const response = await Works.findByIdAndDelete(id)
+        if (response) res.status(200).json({ message: "sucess", data: response })
+        else res.status(400).json({ message: "Could not delete" })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}

--- a/models/works.model.js
+++ b/models/works.model.js
@@ -1,0 +1,37 @@
+import mongoose from "mongoose";
+
+const { Schema, model } = mongoose
+
+const WorksSchema = new Schema({
+    workname: {
+        type: String,
+        required: true
+    },
+    workdesc: {
+        type: String,
+        required: true,
+    },
+    workimg: {
+        type: String,
+        required: true,
+        default: "https://picsum.photos/150/150"
+    },
+    frameworks: {
+        type: Array,
+        required: true,
+    },
+    link_to_project: {
+        type: String,
+        required: true
+    },
+    createdAt: {
+        type: Date,
+        default: new Date(),
+    },
+    modifiedDate: {
+        type: Date,
+        default: new Date()
+    }
+})
+
+export const Works = model('works', WorksSchema)

--- a/routes/works.routes.js
+++ b/routes/works.routes.js
@@ -1,0 +1,17 @@
+import express from "express";
+import { addWork, deleteWork, getWorkById, getWorks, updateWork } from "../controllers/works.controller.js";
+import authenticateRoute from "../middlewares/auth.middleware.js";
+import { validateAddWork, validateDelete, validateUpdateWork } from "../validators/works.validator.js";
+import multer from "./../utils/multer_uploader.js"
+
+const router = express.Router()
+const upload = multer()
+
+router.post('/', upload.none(), validateAddWork, authenticateRoute, addWork)
+router.get('/:id', getWorkById)
+router.get('/', getWorks)
+router.patch('/:id', upload.none(), authenticateRoute, validateUpdateWork, updateWork)
+router.delete('/:id', validateDelete, authenticateRoute, deleteWork)
+
+
+export default router

--- a/swagger.json
+++ b/swagger.json
@@ -9,11 +9,11 @@
     "servers": [
       {
         "url": "http://localhost:6001",
-        "name": "Local server"
+        "description": "Local server"
       },
       {
         "url": "https://mybrand-backend.up.railway.app/",
-        "name": "production server"
+        "description": "production server"
       }
     ],
     "tags": [
@@ -36,6 +36,10 @@
       {
         "name": "SKILLS OPERATIONS",
         "description": "Skills route operations"
+      },
+      {
+        "name": "WORKS OPERATIONS",
+        "description": "Works route operations"
       }
     ],
     "components": {
@@ -153,6 +157,33 @@
             "skillbanner": {
               "type": "string",
               "description": "photo(banner) to a single skill"
+            }
+          }
+        },
+        "Work": {
+          "type": "object",
+          "properties": {
+            "workname": {
+              "type": "string",
+              "description": "name of a work"
+            },
+            "workdesc": {
+              "type": "string",
+              "description": "Description a single work"
+            },
+            "workimg": {
+              "type": "string",
+              "description": "a photo of a work(like screenshoot)"
+            },
+            "link_to_project": {
+              "type": "string",
+              "description": "link of work like homepage"
+            },
+            "frameworks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -795,6 +826,206 @@
                 "application/json": {
                   "schema": {
                     "$ref": "#/components/schemas/Skill"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        }
+      },
+      "/works": {
+        "get": {
+          "summary": "Get all works in array",
+          "tags": ["WORKS OPERATIONS"],
+          "responses": {
+            "200": {
+              "description": "List of works received",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Work"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "404": {
+              "description": "No work found"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "post": {
+          "summary": "send a new work",
+          "tags": ["WORKS OPERATIONS"],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "$ref": "#/components/schemas/Work"
+                }
+              }
+            }
+          },
+          "responses": {
+            "201": {
+              "description": "Work added successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Work"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        }
+      },
+      "/works/{id}": {
+        "patch": {
+          "summary": "Updates an existing work",
+          "tags": ["WORKS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of work"
+            }
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "multipart/form-data": {
+                "schema": {
+                  "$ref": "#/components/schemas/Work"
+                }
+              }
+            }
+          },
+          "responses": {
+            "200": {
+              "description": "work updated successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Work"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "get": {
+          "summary": "retreive a single skill by ID",
+          "tags": ["WORKS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of work"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "work retrieved successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Work"
+                  }
+                }
+              }
+            },
+            "400": {
+              "description": "Bad request"
+            },
+            "401": {
+              "description": "Unauthorized"
+            },
+            "403": {
+              "description": "Token expired/invalid"
+            },
+            "500": {
+              "description": "Internal server error"
+            }
+          }
+        },
+        "delete": {
+          "summary": "Deletes a single work by ID",
+          "tags": ["WORKS OPERATIONS"],
+          "parameters": [
+            {
+              "in": "path",
+              "name": "id",
+              "schema": {
+                "type": "string"
+              },
+              "required": true,
+              "description": "ID of work"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "work deleted successfully",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Work"
                   }
                 }
               }

--- a/utils/server.js
+++ b/utils/server.js
@@ -7,6 +7,7 @@ import usersRoute from '../routes/users.routes.js'
 import loginRoute from '../routes/auth.routes.js'
 import messagesRoute from "../routes/messages.routes.js"
 import skillsRoute from "../routes/skills.routes.js"
+import worksRoute from "../routes/works.routes.js"
 import { createRequire } from "module";
 const require = createRequire(import.meta.url);
 const swaggerJSON = require('./../swagger.json')
@@ -25,6 +26,7 @@ export default function createServer() {
     app.use('/posts', postRoute)
     app.use('/users', usersRoute)
     app.use('/skills', skillsRoute)
+    app.use('/works', worksRoute)
     app.use('/messages', messagesRoute)
     app.use('/login', loginRoute)
 

--- a/validators/works.validator.js
+++ b/validators/works.validator.js
@@ -1,0 +1,81 @@
+import Joi from 'joi';
+import { Works } from '../models/works.model.js';
+
+export async function validateAddWork(req, res, next) {
+    try {
+        const schema = Joi.object({
+            workname: Joi.string().required().label('workname'),
+            workdesc: Joi.string().required().label("workdesc"),
+            workimg: Joi.string().required().label("workimg"),
+            link_to_project: Joi.string().uri().required().label("link_to_project"),
+            frameworks: Joi.array().items(Joi.string()).required().label("frameworks"),
+        })
+
+        const { error } = schema.validate(req.body)
+        if (error) {
+            console.log(error)
+            return res.status(400).json({
+                message: "Unable to save this work..",
+                error: error.message
+            })
+        }
+
+        next()
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function validateUpdateWork(req, res, next) {
+    try {
+        const schema = Joi.object({
+            workname: Joi.string().empty('').label('workname'),
+            workdesc: Joi.string().empty('').label("workdesc"),
+            workimg: Joi.string().empty('').label("workimg"),
+            link_to_project: Joi.string().uri().empty('').label("link_to_project"),
+            frameworks: Joi.array().items(Joi.string()).empty('').label("frameworks"),
+        })
+
+        const { error } = schema.validate(req.body)
+        if (error) {
+            console.log(error)
+            return res.status(400).json({
+                message: "Unable to update this work..",
+                error: error.message
+            })
+        }
+        const id = req.params.id
+        const work = await Works.findById(id)
+        if (!work) return res.status(404).json({ message: "Work not found" })
+
+        next()
+
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}
+
+export async function validateDelete(req, res, next) {
+    try {
+        const id = req.params.id
+        const work = await Works.findById(id)
+        if (!work) return res.status(404).json({ message: "Work not found" })
+
+
+        next()
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({
+            message: err.message
+        })
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
- Add feature to store list of works(portfolio) in the database
#### Description of Task to be completed?
- Now using `/works` route, users should make CRUD operations on `works` model
- get `/works` returns an array of works
- get `/works/{id}` return an object(work) with `id`
- patch `/works/{id}` updates an object(work) with `id`
- delete `/works/{id}` deletes an object(work) with `id`
#### How should this be manually tested?
- Clone this repo
- Enter in the repo folder
- Run `npm ci` from terminal/CMD
- Run `npm start` from terminal/CMD
- Run `npm test` from terminal/CMD to test functionalities
#### Any background context you want to provide?
- Must login to access some routes
- Must have Node JS installed with npm